### PR TITLE
Adjust :php (deprecated) to :http endpoint in Platform.sh routes

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,6 +1,6 @@
 "http://{default}/":
     type: upstream
-    upstream: "sylius:php"
+    upstream: "sylius:http"
 
 "http://www.{default}/":
     type: redirect


### PR DESCRIPTION
Related to Sylius/Sylius#7771. 

According to the Platform.sh docs (https://docs.platform.sh/configuration/routes.html):

`
note For the moment, the value of upstream is always in the form: <application-name>:http. <application-name> is the name defined in .platform.app.yaml file. :php is a deprecated application endpoint; use :http instead. In the future, Platform.sh will support multiple endpoints per application.
`