### PR TITLE
[Platform.sh] Redeploy every month

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -88,3 +88,10 @@ crons:
     reset:
         spec: "0 */1 * * *"
         cmd: "rm -rf web/media/* && php bin/console --env=prod --no-debug sylius:fixtures:load"
+    renewcertificate:
+        # Force a redeploy at 10 am (UTC) on the 3rd of every month.
+        spec: '0 10 3 * *'
+        cmd: |
+            if [ "$PLATFORM_BRANCH" = master ]; then
+                platform redeploy --yes --no-wait
+            fi


### PR DESCRIPTION
To ensure that we will not have any further problem with expired certificates, I have added redeploy cron job according to [platform.sh documentation](https://docs.platform.sh/configuration/routes/https.html#automatic-certificate-renewal)