### PR TITLE
[Maintenance] Remove redundant shop api config

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,8 +1,7 @@
 parameters:
     sylius.security.admin_regex: "^/admin"
     sylius.security.api_regex: "^/api"
-    sylius.security.shop_regex: "^/(?!admin|api/.*|api$|shop-api)[^/]++"
-    shop_api.security.regex: "^/shop-api"
+    sylius.security.shop_regex: "^/(?!admin|api/.*|api$)[^/]++"
 
 security:
     providers:
@@ -78,12 +77,6 @@ security:
                 invalidate_session: false
                 success_handler: sylius.handler.shop_user_logout
             anonymous: true
-
-        shop_api:
-            pattern: "%shop_api.security.regex%"
-            stateless:  true
-            anonymous:  true
-            provider: sylius_shop_user_provider
 
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/


### PR DESCRIPTION
Shop API is not served out-of-the-box in our instance