### PR TITLE
Enable graphql editor in master demo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "sylius/admin-api-bundle": "^1.10-RC.2",
         "bugsnag/bugsnag-symfony": "^1.7",
         "sylius/paypal-plugin": "^1.2",
-        "symfony/dotenv": "^4.4 || ^5.2"
+        "symfony/dotenv": "^4.4 || ^5.2",
+        "webonyx/graphql-php": "^14.11"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
@@ -93,7 +94,8 @@
         "allow-plugins": {
             "symfony/thanks": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "composer/package-versions-deprecated": true
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3462ef03400196f8025e87eb3163d059",
+    "content-hash": "c1e1eddc2da67c3951ca126584aa80ee",
     "packages": [
         {
             "name": "alcohol/iso4217",
@@ -14726,6 +14726,72 @@
             "time": "2021-03-09T10:59:23+00:00"
         },
         {
+            "name": "webonyx/graphql-php",
+            "version": "v14.11.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webonyx/graphql-php.git",
+                "reference": "6070542725b61fc7d0654a8a9855303e5e157434"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/6070542725b61fc7d0654a8a9855303e5e157434",
+                "reference": "6070542725b61fc7d0654a8a9855303e5e157434",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.3",
+                "doctrine/coding-standard": "^6.0",
+                "nyholm/psr7": "^1.2",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "0.12.82",
+                "phpstan/phpstan-phpunit": "0.12.18",
+                "phpstan/phpstan-strict-rules": "0.12.9",
+                "phpunit/phpunit": "^7.2 || ^8.5",
+                "psr/http-message": "^1.0",
+                "react/promise": "2.*",
+                "simpod/php-coveralls-mirror": "^3.0",
+                "squizlabs/php_codesniffer": "3.5.4"
+            },
+            "suggest": {
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "issues": "https://github.com/webonyx/graphql-php/issues",
+                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.6"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-04-13T16:25:32+00:00"
+        },
+        {
             "name": "willdurand/hateoas",
             "version": "3.8.0",
             "source": {
@@ -19018,5 +19084,5 @@
         "php": "^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -1,0 +1,4 @@
+api_platform:
+    graphql:
+        graphiql:
+            enabled: true

--- a/symfony.lock
+++ b/symfony.lock
@@ -945,6 +945,9 @@
     "webmozart/assert": {
         "version": "1.3.0"
     },
+    "webonyx/graphql-php": {
+        "version": "v14.11.6"
+    },
     "willdurand/hateoas": {
         "version": "2.12.0"
     },


### PR DESCRIPTION
Regarding issue https://github.com/Sylius/Sylius/issues/12531 I think we can enable graphql in our master demo and try to keep it working a little bit :)

<img width="1512" alt="Screenshot 2022-05-26 at 08 16 16" src="https://user-images.githubusercontent.com/17534504/170428633-d70b2075-9e6f-483d-b023-968cd41e1c38.png">
