### PR TITLE
css contrast fixes

### DIFF
--- a/templates/info_box.html.twig
+++ b/templates/info_box.html.twig
@@ -14,7 +14,7 @@
         font-size: 16px !important;
         line-height: 1.6;
         box-shadow: 0px 6px 18px 0px rgba(0, 0, 0, 0.22);
-        background: rgba(36, 157, 129, 0.9);
+        background: rgba(16, 116, 93, 0.9);
         backdrop-filter: blur(10px);
         overflow: hidden;
     }
@@ -24,7 +24,7 @@
     }
 
     .info-box a {
-        color: rgba(255, 255, 255, 0.65);
+        color: rgba(255, 255, 255, 0.85);
         text-decoration: underline;
     }
 
@@ -45,7 +45,7 @@
         border-radius: 4px;
         background: rgba(255, 255, 255, 0.1);
         border: 1px solid rgba(255, 255, 255, 0.2);
-        color: rgba(255, 255, 255, 0.65);
+        color: rgba(255, 255, 255, 0.85);
         padding: 4px 10px !important;
     }
 
@@ -71,7 +71,7 @@
     }
 
     .select-color-green {
-        background: rgba(36, 157, 129, 0.9) !important;
+        background: rgba(16, 116, 93, 0.9) !important;
     }
 
     .info-cta {


### PR DESCRIPTION
To comply with accessibility requirements, we need to have a higher contrast between elements. I increased the contrast using tools that help select better contrast levels while preserving the original color hues.